### PR TITLE
The bug is solved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,8 @@ typings/
 
 # DynamoDB Local files
 .dynamodb/
+
+*.png
+*.pdf
+*.html
+*.txt

--- a/zhumayPdf.js
+++ b/zhumayPdf.js
@@ -16,8 +16,8 @@ if (!fs.existsSync('./pdf')){
 const createPDF = (addr, num) => {
     const doc = new PDFDocument();  //starting new pdf here
 
-    doc.pipe(fs.createWriteStream(`./pdf/output${num}.pdf`));
-    files.push(`./pdf/output${num}.pdf`);
+    doc.pipe(fs.createWriteStream(`./pdf/${num}.pdf`));
+    files.push(`./pdf/${num}.pdf`);
     doc.image(addr, 5, 5, {fit: [580, 830], align: 'center', valign: 'center'})
     doc.end();
 
@@ -37,16 +37,6 @@ const merge = require('easy-pdf-merge');
 merge(files,`./ready/ready.pdf`,function(err){
   if(err) {
     return console.log(err)
-  }
-
-  console.log('Success, now deleting files')
-
-  try {
-    fs.unlinkSync('./pdf')
-    fs.unlinkSync('./img')
-    fs.unlinkSync('./temp')        
-  } catch(err) {
-    console.error(err)
   }
 
   console.log('Success')

--- a/zhumaysinba.js
+++ b/zhumaysinba.js
@@ -4,6 +4,8 @@ var rimraf = require("rimraf"); // directory removing
 var cheerio = require('cheerio'); // parser
 const download = require('image-downloader') // image downloader
 const PDFDocument = require('pdfkit'); // pdf creator
+var path = require("path");
+
 
 // Removing old temp if exist
 rimraf.sync("./temp"); // links
@@ -24,7 +26,6 @@ console.log('---------------------')
 // Creating or cleaning temp file for the page data
 let fileTemp = './temp.txt'
 fs.openSync(fileTemp, 'w')
-
 // Scrapper plugins
 class MyPlugin {
     apply(registerAction) {
@@ -56,8 +57,8 @@ const dataGet = () => {
 
         // first script with global info
         const firstScr = $('script')
-        console.log(firstScr.html())
-        console.log(firstScr.text())
+        //console.log(firstScr.html())
+        //console.log(firstScr.text())
         
         // scond script with adress data
         const scrArr = [];
@@ -107,7 +108,6 @@ const dataGet = () => {
 
             }
 
-            // console.log('Data', newData)
             let pdfData = []
 
             for (i = 0; i < newData.length; i++) {
@@ -115,8 +115,6 @@ const dataGet = () => {
                 pdfData.push('./img' + newData[i].slice(58, -56))
             }
             
-            // console.log(pdfData)
-
             // saving local path to imgs for pdf converting
 
             fs.openSync('./pdfData.txt', 'w')
@@ -128,37 +126,41 @@ const dataGet = () => {
 
 
             console.log('==> We got parsed links, there are', newData.length, 'links! ', '\n');
-            console.log('==> Natalya morskaya pehota!')
-
-            console.log('ok, da', '\n')
             
-            // ## Downloading the pictures ##
+            // downloading the pictures
 
-            if (!fs.existsSync('./img')){   //creating img folder after cleaning temp
+            if (!fs.existsSync('./img')){  
                 fs.mkdirSync('./img');
             }
-
             for (i = 0; i < newData.length; i++) {
                 
                 const downOptions = {
                     url: newData[i],
                     dest: './img/'                
-                  }
-            
-                download.image(downOptions)
+                }
+                var file = "./img/" + path.basename(newData[i]).split('?')[0];
+
+                if(!fs.existsSync(file)) {
+                    download.image(downOptions)
                     .then(({ filename }) => {
                         console.log('> Book page was saved to ==>', filename)
                     })
-                    .catch((err) => console.error(err))
-
+                    .catch((err) => {
+                        download.image(downOptions)
+                        .then(({ filename }) => {
+                            console.log('> Book page was saved to ==>', filename)
+                        })
+                    })
+                } else {
+                    console.log("page " + file + " already exists");
+                }
+                
             }
-            
 
         });
         
 
     });
-
 
 }
 


### PR DESCRIPTION
Some books are too big, so the image-downloader starts like 500 threads
trying to download pics as soon as possible. As a result the server
rejects the connection and some pngs are not downloaded. Fortunately
pdf builder notices that and rejects the book.

So, I tried to find library that do not have threaded download, but I
could not do it. They had their own limitations.

I solved it by simply checking if the png was already downloaded. If it
was then it does not download. So we simply run the script twice and it
downloads pages which were rejected first time.

Cherrypicked several other things.